### PR TITLE
Ensure memory is allocated for the null-byte in random_bytes

### DIFF
--- a/fakerandom.c
+++ b/fakerandom.c
@@ -43,7 +43,7 @@ PHP_FUNCTION(fake_random_bytes)
 		Z_PARAM_LONG(length)
 	ZEND_PARSE_PARAMETERS_END();
 
-	retval = emalloc(length);
+	retval = emalloc(length + 1);
 
 	for (size_t i = 0; i < length; i++) {
 	  retval[i] = (char)((i + 1) % 256);


### PR DESCRIPTION
I was running into an issue with `random_bytes` causing the PHP process to crash. I narrowed this down to `emalloc` not being allocated extra memory for the null-byte.