### PR TITLE
Update official GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "PHP_API=$(php-config --phpapi)" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         run: |
           phpize
@@ -48,7 +48,7 @@ jobs:
           make
           make test REPORT_EXIT_STATUS=1 NO_INTERACTION=1 TESTS="--show-all"
       - name: Save artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: fakerandom_${{ env.PHP_API }}.so
           path: modules/fakerandom.so
@@ -60,7 +60,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Combine artifacts
         run: |
           mkdir -p output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,11 @@ jobs:
           sha256sum *.so > SHA256SUM
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           prerelease: false
       - name: Upload release assets


### PR DESCRIPTION
This updates the official actions, and replaces the deprecated `actions/create-release` action with an action GitHub's recommended as a replacement.

This has been tested [here](https://github.com/AlsoAsked/php-fakerandom/actions/runs/12395218901).